### PR TITLE
Add whitelist

### DIFF
--- a/contracts/vIDIA.sol
+++ b/contracts/vIDIA.sol
@@ -165,7 +165,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
      @return boolean representing if transfer was successful
      */
     function transfer(address to, uint256 amount) public override returns (bool) {
-        require(EnumerableSet.contains(whitelistAddresses, to) || EnumerableSet.contains(whitelistAddresses, _msgSender()), 'Destination address is not whitelisted');
+        require(EnumerableSet.contains(whitelistAddresses, to) || EnumerableSet.contains(whitelistAddresses, _msgSender()), 'Origin and dest address not in whitelist');
         return ERC20.transfer(to, amount);
     }
 
@@ -178,7 +178,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
      @return boolean representing if transfer was successful
      */
     function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
-        require(EnumerableSet.contains(whitelistAddresses, from) || EnumerableSet.contains(whitelistAddresses, to), 'Destination address is not whitelisted');
+        require(EnumerableSet.contains(whitelistAddresses, from) || EnumerableSet.contains(whitelistAddresses, to), 'Origin and dest address not in whitelist');
         return ERC20.transferFrom(from, to, amount);
     }
 


### PR DESCRIPTION
1. remove whitelist feature - for safety, ensures users dont send to old launchpad addresses
2. why not use accesscontrolenumerable and hasrole for whitelist? library allows any address with the role to add other whitelisted addresses. safer to be conservative with permissions to reduce exposure
3. no tests - currently, vidia branch doesnt compile. should i make fixes to vidia branch to add tests?