### PR TITLE
Add feefunctions tests

### DIFF
--- a/contracts/vIDIA.sol
+++ b/contracts/vIDIA.sol
@@ -24,6 +24,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
     uint256 public totalStakedAmount;
     uint256 public rewardSum; // (1/T1 + 1/T2 + 1/T3)
     address public tokenAddress;
+
     address admin;
 
     struct UserInfo {

--- a/contracts/vIDIA.sol
+++ b/contracts/vIDIA.sol
@@ -17,7 +17,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
     uint256 public unstakingDelay = 86400 * 14; // 2 weeks in seconds
 
     // Fees for different actions. All fees denoted in basis points
-    uint256 public skipUnstakeDelayFee = 2000; // initialzed at 20%
+    uint256 public skipDelayFee = 2000; // initialzed at 20%
     uint256 public cancelUnstakeFee = 200; // initialized at 2%
 
     uint256 public accumulatedFee;
@@ -113,7 +113,6 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
         userInfo[_msgSender()].unstakeAt = unstakeAt;
 
         userInfo[_msgSender()].unstakedAmount = amount;
-        burn(userInfo[_msgSender()].unstakedAmount);
         emit Unstake(_msgSender(), amount);
     }
 
@@ -135,7 +134,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
     function claimStaked(uint256 amount) public {
         claimReward();
 
-        uint256 fee = (amount * skipUnstakeDelayFee) / ONE_HUNDRED;
+        uint256 fee = (amount * skipDelayFee) / ONE_HUNDRED;
         uint256 withdrawAmount = amount - fee;
 
         totalStakedAmount -= amount;
@@ -164,7 +163,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
             'Can unstake without paying fee'
         );
 
-        uint256 fee = (amount * skipUnstakeDelayFee) / ONE_HUNDRED;
+        uint256 fee = (amount * skipDelayFee) / ONE_HUNDRED;
         uint256 withdrawAmount = amount - fee;
 
         if (totalStakedAmount != 0) {
@@ -191,7 +190,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
     function cancelPendingUnstake(uint256 amount) public {
         require(
             userInfo[_msgSender()].unstakeAt > block.timestamp,
-            'Can unstake and restake paying fee'
+            'Can restake without paying fee'
         );
         claimReward();
 
@@ -218,14 +217,12 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
     // claim reward and reset user's reward sum
     function claimReward() public {
         uint256 reward = calculateUserReward();
-        if (reward >= 0) {
-            // reset user's rewards sum
-            userInfo[_msgSender()].lastRewardSum = rewardSum;
-            // transfer reward to user
-            ERC20 claimedTokens = ERC20(tokenAddress);
-            claimedTokens.safeTransfer(_msgSender(), reward);
-            emit ClaimReward(_msgSender(), reward);
-        }
+        // reset user's rewards sum
+        userInfo[_msgSender()].lastRewardSum = rewardSum;
+        // transfer reward to user
+        ERC20 claimedTokens = ERC20(tokenAddress);
+        claimedTokens.safeTransfer(_msgSender(), reward);
+        emit ClaimReward(_msgSender(), reward);
     }
 
     /** 
@@ -233,13 +230,13 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
      @dev Requires fee setter role and fee must be below 10000 basis pts
      @param newFee the new fee
      */
-    function updateSkipUnstakeDelayFee(uint256 newFee) external {
+    function updateSkipDelayFee(uint256 newFee) external {
         require(
             hasRole(FEE_SETTER_ROLE, _msgSender()),
             'Must have fee setter role'
         );
         require(newFee <= 10000, 'Fee must be less than 100%');
-        skipUnstakeDelayFee = newFee;
+        skipDelayFee = newFee;
     }
 
     /** 
@@ -261,7 +258,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
      @dev Requires delay setter role and existing wait times will not change
      @param newDelay the new delay
      */
-    function updateUnvestingDelay(uint24 newDelay) external {
+    function updateUnstakingDelay(uint24 newDelay) external {
         require(
             hasRole(DELAY_SETTER_ROLE, _msgSender()),
             'Must have delay setter role'

--- a/contracts/vIDIA.sol
+++ b/contracts/vIDIA.sol
@@ -137,14 +137,16 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
 
         uint256 fee = (amount * skipDelayFee) / ONE_HUNDRED;
         uint256 withdrawAmount = amount - fee;
+        uint256 divisor = totalStakedAmount - userInfo[_msgSender()].stakedAmount;
 
+        if (divisor != 0) {
+            // mul by FACTOR of 10**30 to reduce truncation
+            rewardSum += (fee * FACTOR) / divisor;
+            userInfo[_msgSender()].lastRewardSum = rewardSum;
+        }
+        
         totalStakedAmount -= amount;
         userInfo[_msgSender()].stakedAmount -= amount;
-
-        if (totalStakedAmount != 0) {
-            // mul by FACTOR of 10**18 to reduce truncation
-            rewardSum += (fee * FACTOR) / totalStakedAmount;
-        }
         accumulatedFee += fee;
 
         burn(amount);
@@ -163,13 +165,16 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
             userInfo[_msgSender()].unstakeAt > block.timestamp,
             'Can unstake without paying fee'
         );
+        claimReward();
 
         uint256 fee = (amount * skipDelayFee) / ONE_HUNDRED;
         uint256 withdrawAmount = amount - fee;
+        uint256 divisor = totalStakedAmount - userInfo[_msgSender()].stakedAmount;
 
-        if (totalStakedAmount != 0) {
-            // mul by FACTOR of 10**18 to reduce truncation
-            rewardSum += (fee * FACTOR) / totalStakedAmount;
+        if (divisor != 0) {
+            // mul by FACTOR of 10**30 to reduce truncation
+            rewardSum += (fee * FACTOR) / divisor;
+            userInfo[_msgSender()].lastRewardSum = rewardSum;
         }
         accumulatedFee += fee;
 
@@ -192,16 +197,18 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
             userInfo[_msgSender()].unstakeAt > block.timestamp,
             'Can restake without paying fee'
         );
+        claimReward();
 
         uint256 fee = (amount * cancelUnstakeFee) / ONE_HUNDRED;
         uint256 stakeAmount = amount - fee;
+        uint256 divisor = totalStakedAmount - userInfo[_msgSender()].stakedAmount;
 
-        if (totalStakedAmount != 0) {
-            // mul by FACTOR of 10**18 to reduce truncation
-            rewardSum += (fee * FACTOR) / totalStakedAmount;
+        if (divisor != 0) {
+            // mul by FACTOR of 10**30 to reduce truncation
+            rewardSum += (fee * FACTOR) / divisor;
+            userInfo[_msgSender()].lastRewardSum = rewardSum;
         }
         accumulatedFee += fee;
-        claimReward();
 
         userInfo[_msgSender()].unstakedAmount -= amount;
         if (userInfo[_msgSender()].unstakedAmount == 0) {
@@ -268,8 +275,8 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
 
     /** 
      @notice Calculates user reward
-     @dev formula: amount * (global_reward_sum - user_reward_sum) / 10**18
-     @dev we perform div 10**18 as rewardsum is inflated by 10**18 to reduce truncation
+     @dev formula: amount * (global_reward_sum - user_reward_sum) / 10**30
+     @dev we perform div 10**30 as rewardsum is inflated by 10**30 to reduce truncation
      @return uint256 amount of underlying tokens the user has earned from fees
      */
     function calculateUserReward() public view returns (uint256) {

--- a/contracts/vIDIA.sol
+++ b/contracts/vIDIA.sol
@@ -10,7 +10,7 @@ import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 contract vIDIA is AccessControlEnumerable, IFTokenStandard {
     using SafeERC20 for ERC20;
 
-    uint256 private constant FACTOR = 10**18;
+    uint256 private constant FACTOR = 10**30;
     uint256 private constant ONE_HUNDRED = 10000; // one hundred in basis points
 
     // delay for unstaking token
@@ -192,7 +192,6 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
             userInfo[_msgSender()].unstakeAt > block.timestamp,
             'Can restake without paying fee'
         );
-        claimReward();
 
         uint256 fee = (amount * cancelUnstakeFee) / ONE_HUNDRED;
         uint256 stakeAmount = amount - fee;
@@ -202,6 +201,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
             rewardSum += (fee * FACTOR) / totalStakedAmount;
         }
         accumulatedFee += fee;
+        claimReward();
 
         userInfo[_msgSender()].unstakedAmount -= amount;
         if (userInfo[_msgSender()].unstakedAmount == 0) {
@@ -211,7 +211,6 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
         userInfo[_msgSender()].stakedAmount += stakeAmount;
         totalStakedAmount += stakeAmount;
         _mint(_msgSender(), stakeAmount);
-        userInfo[_msgSender()].lastRewardSum = rewardSum;
         emit CancelPendingUnstake(_msgSender(), fee, stakeAmount);
     }
 

--- a/contracts/vIDIA.sol
+++ b/contracts/vIDIA.sol
@@ -113,6 +113,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
         userInfo[_msgSender()].unstakeAt = unstakeAt;
 
         userInfo[_msgSender()].unstakedAmount = amount;
+        burn(userInfo[_msgSender()].unstakedAmount);
         emit Unstake(_msgSender(), amount);
     }
 
@@ -176,7 +177,6 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
         if (userInfo[_msgSender()].unstakedAmount == 0) {
             userInfo[_msgSender()].unstakeAt = 0;
         }
-        burn(amount);
         ERC20(tokenAddress).safeTransfer(_msgSender(), withdrawAmount);
         emit ClaimPendingUnstake(_msgSender(), fee, withdrawAmount);
     }
@@ -210,6 +210,7 @@ contract vIDIA is AccessControlEnumerable, IFTokenStandard {
 
         userInfo[_msgSender()].stakedAmount += stakeAmount;
         totalStakedAmount += stakeAmount;
+        _mint(_msgSender(), stakeAmount);
         userInfo[_msgSender()].lastRewardSum = rewardSum;
         emit CancelPendingUnstake(_msgSender(), fee, stakeAmount);
     }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -18,13 +18,6 @@ module.exports = {
     },
   },
   networks: {
-    hardhat: {
-      mining: {
-        auto: false,
-        interval: 0,
-      },
-      allowUnlimitedContractSize: false,
-    },
     bsc_test: {
       url: 'https://data-seed-prebsc-1-s1.binance.org:8545',
       chainId: 97,

--- a/test/test-vIDIA.ts
+++ b/test/test-vIDIA.ts
@@ -5,15 +5,23 @@ import { expect } from 'chai'
 import { Contract } from '@ethersproject/contracts'
 import { mineNext, getBlockTime, mineTimeDelta } from './helpers'
 import { first } from 'lodash'
+import { BigNumber } from 'ethers'
 
 const MaxUint256 = ethers.constants.MaxUint256
 const WeiPerEth = ethers.constants.WeiPerEther
 const _1 = ethers.constants.One
-const _10000 = ethers.BigNumber.from(10000)
+const _10 = BigNumber.from(10)
+const _10000 = BigNumber.from(10000)
+const FACTOR = BigNumber.from(_10.pow(BigNumber.from(30)))
 const TWO_WEEKS = 14 * 86400
 
 const convToBN = (num: number) => {
-  return ethers.BigNumber.from(num).mul(WeiPerEth)
+  return BigNumber.from(num).mul(WeiPerEth)
+}
+
+const checkWithinTolerance = (test: BigNumber, target: BigNumber, tolerance = _10) => {
+  expect(test.add(tolerance).gte(target))
+  expect(test.sub(tolerance).lte(target))
 }
 
 export default describe('vIDIA', function () {
@@ -41,7 +49,7 @@ export default describe('vIDIA', function () {
     underlying = await TestTokenFactory.connect(owner).deploy(
       'Test Vest Token',
       'Vest',
-      MaxUint256
+      convToBN(200)
     )
     vIDIA = await vIDIAFactory.deploy(
       'vIDIA contract',
@@ -217,10 +225,11 @@ export default describe('vIDIA', function () {
     await vIDIA.unstake(convToBN(stakeAmt-1))
 
     // sums up to stakeAmt-1 for LOC coverage
-    const withdrawAmt = [convToBN(1), convToBN(8), convToBN(0), convToBN(102), convToBN(88)]
+    const withdrawAmt = [convToBN(1), convToBN(6), convToBN(0), convToBN(99), convToBN(93)] 
 
     let userVidiaBalance = await vIDIA.balanceOf(owner.address)
     let userUnderlying = await underlying.balanceOf(owner.address)
+    let userStakedAmt = (await vIDIA.userInfo(owner.address)).stakedAmount
     let userUnstakingAmt = (await vIDIA.userInfo(owner.address)).unstakedAmount
     let contractUnderlying = await underlying.balanceOf(vIDIA.address)
     let sumFees = await vIDIA.accumulatedFee()
@@ -231,15 +240,28 @@ export default describe('vIDIA', function () {
       const fee = feePercentBasisPts.mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
       const receiveAmt = withdrawAmt[i].sub(fee)
 
+      const newRewardSum = 
+        (await vIDIA.rewardSum())
+          .add(fee.mul(FACTOR)
+            .div(await vIDIA.totalStakedAmount()))
+
+      const reward = 
+        userStakedAmt.mul(
+          newRewardSum.sub((await vIDIA.userInfo(owner.address)).lastRewardSum))
+            .div(FACTOR)
+
       expect(await vIDIA.claimPendingUnstake(withdrawAmt[i]))
         .to.emit(vIDIA, 'ClaimPendingUnstake')
         .withArgs(owner.address, fee, receiveAmt)
         .to.emit(underlying, 'Transfer')
         .withArgs(vIDIA.address, owner.address, receiveAmt)
 
+      checkWithinTolerance(reward, sumFees.add(fee)) // default tolerance = 10wei
+      checkWithinTolerance(await vIDIA.calculateUserReward(), sumFees.add(fee)) // default tolerance = 10wei
+      checkWithinTolerance(await vIDIA.accumulatedFee(), sumFees.add(fee)) // default tolerance = 10wei
+
       expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance)
       expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(receiveAmt))
-      expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
       expect((await vIDIA.userInfo(owner.address)).unstakedAmount).to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
       expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying.sub(receiveAmt))
 
@@ -277,7 +299,18 @@ export default describe('vIDIA', function () {
       const fee = feePercentBasisPts.mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
       const receiveAmt = withdrawAmt[i].sub(fee)
 
-      const reward = await vIDIA.calculateUserReward()
+      const newRewardSum = 
+        (await vIDIA.rewardSum())
+          .add(fee.mul(FACTOR)
+            .div(await vIDIA.totalStakedAmount()))
+
+      const reward = 
+        userStakedAmt.mul(
+          newRewardSum.sub((await vIDIA.userInfo(owner.address)).lastRewardSum))
+            .div(FACTOR)
+
+      // reward paid out should always be within tolerance of +-10wei of fee
+      checkWithinTolerance(reward, fee) // default tolerance = 10wei
 
       expect(await vIDIA.cancelPendingUnstake(withdrawAmt[i]))
         .to.emit(vIDIA, 'ClaimReward')
@@ -287,25 +320,32 @@ export default describe('vIDIA', function () {
         .to.emit(vIDIA, 'CancelPendingUnstake')
         .withArgs(owner.address, fee, receiveAmt)
 
-      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance.add(receiveAmt))
-      expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(reward)) // receive reward
+      expect(await underlying.balanceOf(owner.address)) // full fee since owner owns 100% of totalstaked
+        .to.equal(userUnderlying.add(reward)) 
+      expect(await underlying.balanceOf(vIDIA.address)) // full fee sent out since its all owner
+        .to.equal(contractUnderlying.sub(reward))
+
+      expect((await vIDIA.userInfo(owner.address)).unstakedAmount) // reduce unstakedAmt by amt
+        .to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
+      expect(await vIDIA.balanceOf(owner.address)) // receives receiveAmt which is amt - fee
+        .to.equal(userVidiaBalance.add(receiveAmt))
+      expect((await vIDIA.userInfo(owner.address)).stakedAmount) // inc stakedAmt by receiveAmt
+        .to.equal(userStakedAmt.add(receiveAmt))
+        
       expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
-      expect((await vIDIA.userInfo(owner.address)).unstakedAmount).to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
-      expect((await vIDIA.userInfo(owner.address)).stakedAmount).to.equal(userStakedAmt.add(receiveAmt))
-      expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying)
   
       userVidiaBalance = userVidiaBalance.add(receiveAmt)
       userUnderlying = userUnderlying.add(reward)
       userUnstakingAmt = userUnstakingAmt.sub(withdrawAmt[i])
       contractUnderlying = contractUnderlying.sub(reward)
-      userStakedAmt = userStakedAmt.add(receiveAmt)
       sumFees = sumFees.add(fee)
+      userStakedAmt = userStakedAmt.add(receiveAmt)
     }
 
     // test failure mode
     await mineTimeDelta(TWO_WEEKS)
-    await expect(vIDIA.claimPendingUnstake(0))
-      .to.be.revertedWith('Can unstake without paying fee')
+    await expect(vIDIA.cancelPendingUnstake(0))
+      .to.be.revertedWith('Can restake without paying fee')
   })
 
   it('test claimunstaked', async () => {

--- a/test/test-vIDIA.ts
+++ b/test/test-vIDIA.ts
@@ -9,10 +9,12 @@ import { BigNumber } from 'ethers'
 
 const MaxUint256 = ethers.constants.MaxUint256
 const WeiPerEth = ethers.constants.WeiPerEther
+const _0 = ethers.constants.Zero
 const _1 = ethers.constants.One
 const _10 = BigNumber.from(10)
 const _10000 = BigNumber.from(10000)
 const FACTOR = BigNumber.from(_10.pow(BigNumber.from(30)))
+
 const TWO_WEEKS = 14 * 86400
 
 const convToBN = (num: number) => {
@@ -20,8 +22,8 @@ const convToBN = (num: number) => {
 }
 
 const checkWithinTolerance = (test: BigNumber, target: BigNumber, tolerance = _10) => {
-  expect(test.add(tolerance).gte(target))
-  expect(test.sub(tolerance).lte(target))
+  expect(test.add(tolerance).gte(target)).to.eq(true, `failed gte tolerance, ${test.toString()} and ${target.toString()}`)
+  expect(test.sub(tolerance).lte(target)).to.eq(true, `failed lte tolerance, ${test.toString()} and ${target.toString()}`)
 }
 
 export default describe('vIDIA', function () {
@@ -43,13 +45,11 @@ export default describe('vIDIA', function () {
     // mined.
     const vIDIAFactory = await ethers.getContractFactory('vIDIA')
 
-    owner = (await ethers.getSigners())[0]
-    vester = (await ethers.getSigners())[1]
     const TestTokenFactory = await ethers.getContractFactory('GenericToken')
     underlying = await TestTokenFactory.connect(owner).deploy(
       'Test Vest Token',
       'Vest',
-      convToBN(200)
+      MaxUint256
     )
     vIDIA = await vIDIAFactory.deploy(
       'vIDIA contract',
@@ -57,6 +57,10 @@ export default describe('vIDIA', function () {
       owner.address,
       underlying.address
     )
+
+    await underlying.transfer(vester.address, convToBN(1000))
+    await underlying.approve(vIDIA.address, MaxUint256)
+    await underlying.connect(vester).approve(vIDIA.address, MaxUint256)
   })
 
   it('test static funcs', async function () {
@@ -178,7 +182,10 @@ export default describe('vIDIA', function () {
 
   it('test claimstaked', async () => {
     await underlying.approve(vIDIA.address, MaxUint256)
-    await vIDIA.stake(convToBN(200))
+    const ownerStakeAmt = convToBN(200)
+    const rewarderStakeAmt = convToBN(1)
+    await vIDIA.stake(ownerStakeAmt)
+    await vIDIA.connect(vester).stake(rewarderStakeAmt)
 
     const withdrawAmt = [convToBN(1), convToBN(12), convToBN(0), convToBN(123)]
 
@@ -187,42 +194,57 @@ export default describe('vIDIA', function () {
     let contractUnderlying = await underlying.balanceOf(vIDIA.address)
     let sumFees = await vIDIA.accumulatedFee()
 
-    const feePercentBasisPts = await vIDIA.skipDelayFee()
-
     for (let i = 0; i < withdrawAmt.length; i++) {
       
-      const fee = feePercentBasisPts.mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
+      const fee = (await vIDIA.skipDelayFee()).mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
       const receiveAmt = withdrawAmt[i].sub(fee)
 
-      const reward = await vIDIA.calculateUserReward()
+      const newRewardSum = 
+        (await vIDIA.rewardSum())
+          .add(fee.mul(FACTOR)
+            .div(rewarderStakeAmt))
+
+      const reward = 
+        rewarderStakeAmt.mul(
+          newRewardSum.sub((await vIDIA.userInfo(vester.address)).lastRewardSum))
+            .div(FACTOR)
 
       expect(await vIDIA.claimStaked(withdrawAmt[i]))
         .to.emit(vIDIA, 'ClaimReward')
-        .withArgs(owner.address, reward)
+        .withArgs(owner.address, _0)
         .to.emit(underlying, 'Transfer')
-        .withArgs(vIDIA.address, owner.address, reward)
+        .withArgs(vIDIA.address, owner.address, _0)
         .to.emit(vIDIA, 'ClaimStaked')
         .withArgs(owner.address, fee, receiveAmt)
         .to.emit(underlying, 'Transfer')
         .withArgs(vIDIA.address, owner.address, receiveAmt)
 
-      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance.sub(withdrawAmt[i]))
-      expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(receiveAmt).add(reward))
-      expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
-      expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying.sub(receiveAmt).sub(reward))
+      expect(await vIDIA.calculateUserReward()).to.eq(_0) // fees should never accrue to for fee payer
+
+      // these are the state changes every loop
+      sumFees = sumFees.add(fee)
+      expect(await vIDIA.accumulatedFee()).to.equal(sumFees)
+      expect(await vIDIA.connect(vester).calculateUserReward()).to.eq(sumFees) // all fees to vester
+      checkWithinTolerance(reward, sumFees) // default tolerance = 10wei
 
       userVidiaBalance = userVidiaBalance.sub(withdrawAmt[i])
-      userUnderlying = userUnderlying.add(receiveAmt).add(reward)
-      contractUnderlying = contractUnderlying.sub(receiveAmt).sub(reward)
-      sumFees = sumFees.add(fee)
+      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance)
+
+      userUnderlying = userUnderlying.add(receiveAmt)
+      expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying)
+
+      contractUnderlying = contractUnderlying.sub(receiveAmt)
+      expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying)
     }
   })
 
   it('test claimpendingunstake with pending unstake', async () => {
     await underlying.approve(vIDIA.address, MaxUint256)
-    const stakeAmt = 200
-    await vIDIA.stake(convToBN(stakeAmt))
-    await vIDIA.unstake(convToBN(stakeAmt-1))
+    const ownerStakeAmt = convToBN(200)
+    const rewarderStakeAmt = convToBN(1)
+    await vIDIA.stake(ownerStakeAmt)
+    await vIDIA.connect(vester).stake(rewarderStakeAmt)
+    await vIDIA.unstake(ownerStakeAmt.sub(rewarderStakeAmt))
 
     // sums up to stakeAmt-1 for LOC coverage
     const withdrawAmt = [convToBN(1), convToBN(6), convToBN(0), convToBN(99), convToBN(93)] 
@@ -234,41 +256,47 @@ export default describe('vIDIA', function () {
     let contractUnderlying = await underlying.balanceOf(vIDIA.address)
     let sumFees = await vIDIA.accumulatedFee()
 
-    const feePercentBasisPts = await vIDIA.skipDelayFee()
-
     for (let i = 0; i < withdrawAmt.length; i++) {
-      const fee = feePercentBasisPts.mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
+      const fee = (await vIDIA.skipDelayFee()).mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
       const receiveAmt = withdrawAmt[i].sub(fee)
 
       const newRewardSum = 
         (await vIDIA.rewardSum())
           .add(fee.mul(FACTOR)
-            .div(await vIDIA.totalStakedAmount()))
+            .div(rewarderStakeAmt))
 
       const reward = 
-        userStakedAmt.mul(
-          newRewardSum.sub((await vIDIA.userInfo(owner.address)).lastRewardSum))
+        rewarderStakeAmt.mul(
+          newRewardSum.sub((await vIDIA.userInfo(vester.address)).lastRewardSum))
             .div(FACTOR)
 
       expect(await vIDIA.claimPendingUnstake(withdrawAmt[i]))
+        .to.emit(vIDIA, 'ClaimReward')
+        .withArgs(owner.address, _0)
+        .to.emit(underlying, 'Transfer')
+        .withArgs(vIDIA.address, owner.address, _0)
         .to.emit(vIDIA, 'ClaimPendingUnstake')
         .withArgs(owner.address, fee, receiveAmt)
         .to.emit(underlying, 'Transfer')
         .withArgs(vIDIA.address, owner.address, receiveAmt)
 
-      checkWithinTolerance(reward, sumFees.add(fee)) // default tolerance = 10wei
-      checkWithinTolerance(await vIDIA.calculateUserReward(), sumFees.add(fee)) // default tolerance = 10wei
-      checkWithinTolerance(await vIDIA.accumulatedFee(), sumFees.add(fee)) // default tolerance = 10wei
-
+      // no change
+      expect(await vIDIA.calculateUserReward()).to.eq(_0) // fees should never accrue to for fee payer
       expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance)
-      expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(receiveAmt))
-      expect((await vIDIA.userInfo(owner.address)).unstakedAmount).to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
-      expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying.sub(receiveAmt))
+
+      sumFees = sumFees.add(fee)
+      expect(await vIDIA.accumulatedFee()).to.equal(sumFees)
+      expect(await vIDIA.connect(vester).calculateUserReward()).to.eq(sumFees) // all fees to vester
+      checkWithinTolerance(reward, sumFees) // default tolerance = 10wei
 
       userUnderlying = userUnderlying.add(receiveAmt)
+      expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying)
+
       userUnstakingAmt = userUnstakingAmt.sub(withdrawAmt[i])
+      expect((await vIDIA.userInfo(owner.address)).unstakedAmount).to.equal(userUnstakingAmt)
+
       contractUnderlying = contractUnderlying.sub(receiveAmt)
-      sumFees = sumFees.add(fee)
+      expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying)
     }
 
     // test failure mode
@@ -279,10 +307,12 @@ export default describe('vIDIA', function () {
 
   it('test cancelpendingunstake with pending unstake', async () => {
     await underlying.approve(vIDIA.address, MaxUint256)
-    const stakeAmt = 200
-    await vIDIA.stake(convToBN(stakeAmt))
-    await vIDIA.unstake(convToBN(stakeAmt-1))
-  
+    const ownerStakeAmt = convToBN(200)
+    const rewarderStakeAmt = convToBN(1)
+    await vIDIA.stake(ownerStakeAmt)
+    await vIDIA.connect(vester).stake(rewarderStakeAmt)
+    await vIDIA.unstake(ownerStakeAmt.sub(rewarderStakeAmt))
+
     // sums up to stakeAmt-1 for LOC coverage
     const withdrawAmt = [convToBN(1), convToBN(6), convToBN(0), convToBN(99), convToBN(93)] 
 
@@ -293,53 +323,52 @@ export default describe('vIDIA', function () {
     let contractUnderlying = await underlying.balanceOf(vIDIA.address)
     let sumFees = await vIDIA.accumulatedFee()
 
-    const feePercentBasisPts = await vIDIA.cancelUnstakeFee()
-
     for (let i = 0; i < withdrawAmt.length; i++) {
-      const fee = feePercentBasisPts.mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
+      const fee = (await vIDIA.cancelUnstakeFee()).mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
       const receiveAmt = withdrawAmt[i].sub(fee)
 
       const newRewardSum = 
         (await vIDIA.rewardSum())
           .add(fee.mul(FACTOR)
-            .div(await vIDIA.totalStakedAmount()))
+            .div(rewarderStakeAmt))
 
       const reward = 
-        userStakedAmt.mul(
-          newRewardSum.sub((await vIDIA.userInfo(owner.address)).lastRewardSum))
+        rewarderStakeAmt.mul(
+          newRewardSum.sub((await vIDIA.userInfo(vester.address)).lastRewardSum))
             .div(FACTOR)
-
-      // reward paid out should always be within tolerance of +-10wei of fee
-      checkWithinTolerance(reward, fee) // default tolerance = 10wei
-
+      
       expect(await vIDIA.cancelPendingUnstake(withdrawAmt[i]))
         .to.emit(vIDIA, 'ClaimReward')
-        .withArgs(owner.address, reward)
+        .withArgs(owner.address, _0)
         .to.emit(underlying, 'Transfer')
-        .withArgs(vIDIA.address, owner.address, reward)
+        .withArgs(vIDIA.address, owner.address, _0)
         .to.emit(vIDIA, 'CancelPendingUnstake')
         .withArgs(owner.address, fee, receiveAmt)
 
-      expect(await underlying.balanceOf(owner.address)) // full fee since owner owns 100% of totalstaked
-        .to.equal(userUnderlying.add(reward)) 
-      expect(await underlying.balanceOf(vIDIA.address)) // full fee sent out since its all owner
-        .to.equal(contractUnderlying.sub(reward))
+      expect(await vIDIA.calculateUserReward()).to.eq(_0) // fees should never accrue to for fee payer
 
-      expect((await vIDIA.userInfo(owner.address)).unstakedAmount) // reduce unstakedAmt by amt
-        .to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
-      expect(await vIDIA.balanceOf(owner.address)) // receives receiveAmt which is amt - fee
-        .to.equal(userVidiaBalance.add(receiveAmt))
-      expect((await vIDIA.userInfo(owner.address)).stakedAmount) // inc stakedAmt by receiveAmt
-        .to.equal(userStakedAmt.add(receiveAmt))
-        
-      expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
-  
-      userVidiaBalance = userVidiaBalance.add(receiveAmt)
-      userUnderlying = userUnderlying.add(reward)
-      userUnstakingAmt = userUnstakingAmt.sub(withdrawAmt[i])
-      contractUnderlying = contractUnderlying.sub(reward)
       sumFees = sumFees.add(fee)
+      expect(await vIDIA.accumulatedFee()).to.equal(sumFees)
+      expect(await vIDIA.connect(vester).calculateUserReward()).to.eq(sumFees) // all fees to vester
+      checkWithinTolerance(reward, sumFees) // default tolerance = 10wei
+
+      // no change
+      expect(await underlying.balanceOf(owner.address)) // full fee since owner owns 100% of totalstaked
+        .to.equal(userUnderlying) 
+      expect(await underlying.balanceOf(vIDIA.address)) // full fee sent out since its all owner
+        .to.equal(contractUnderlying)
+
+      userVidiaBalance = userVidiaBalance.add(receiveAmt)
+      expect(await vIDIA.balanceOf(owner.address)) // receives receiveAmt which is amt - fee
+        .to.equal(userVidiaBalance)
+
+      userUnstakingAmt = userUnstakingAmt.sub(withdrawAmt[i])
+      expect((await vIDIA.userInfo(owner.address)).unstakedAmount) // reduce unstakedAmt by amt
+        .to.equal(userUnstakingAmt)
+
       userStakedAmt = userStakedAmt.add(receiveAmt)
+      expect((await vIDIA.userInfo(owner.address)).stakedAmount) // inc stakedAmt by receiveAmt
+        .to.equal(userStakedAmt)
     }
 
     // test failure mode

--- a/test/test-vIDIA.ts
+++ b/test/test-vIDIA.ts
@@ -3,12 +3,14 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { ethers } from 'hardhat'
 import { expect } from 'chai'
 import { Contract } from '@ethersproject/contracts'
-import { mineNext, getBlockTime } from './helpers'
+import { mineNext, getBlockTime, mineTimeDelta } from './helpers'
 import { first } from 'lodash'
 
 const MaxUint256 = ethers.constants.MaxUint256
 const WeiPerEth = ethers.constants.WeiPerEther
-const one = ethers.constants.One
+const _1 = ethers.constants.One
+const _10000 = ethers.BigNumber.from(10000)
+const TWO_WEEKS = 14 * 86400
 
 const convToBN = (num: number) => {
   return ethers.BigNumber.from(num).mul(WeiPerEth)
@@ -19,7 +21,7 @@ export default describe('vIDIA', function () {
   this.timeout(0)
 
   let vIDIA: Contract
-  let VestToken: Contract
+  let underlying: Contract
   let owner: SignerWithAddress
   let vester: SignerWithAddress
 
@@ -36,92 +38,55 @@ export default describe('vIDIA', function () {
     owner = (await ethers.getSigners())[0]
     vester = (await ethers.getSigners())[1]
     const TestTokenFactory = await ethers.getContractFactory('GenericToken')
-    VestToken = await TestTokenFactory.connect(owner).deploy(
+    underlying = await TestTokenFactory.connect(owner).deploy(
       'Test Vest Token',
       'Vest',
-      '21000000000000000000000000' // 21 million * 10**18
+      MaxUint256
     )
     vIDIA = await vIDIAFactory.deploy(
       'vIDIA contract',
-      'VIDIA',
+      'vIDIA',
       owner.address,
-      VestToken.address
+      underlying.address
     )
   })
 
+  it('test setters', async function () {
+    const value = [0, 100, 200, 300]
+    const fns = [
+      { set: vIDIA.updateSkipDelayFee, get: vIDIA.skipDelayFee},
+      { set: vIDIA.updateCancelUnstakeFee, get: vIDIA.cancelUnstakeFee},
+      { set: vIDIA.updateUnstakingDelay, get: vIDIA.unstakingDelay}
+    ]
 
-  it('deploys', async function () {
-    // get owner
-    const [owner] = await ethers.getSigners()
+    for (let i = 0; i < fns.length; i++) {
+      for (let j = 0; j < value.length; j++) {
+        await fns[i].set(value[j])
+        expect(await fns[i].get()).to.eq(value[j])
+      }
 
-    // deploy
-    const vIDIAFactory = await ethers.getContractFactory('vIDIA')
-
-    const testTokenAddress = '0x0b15Ddf19D47E6a86A56148fb4aFFFc6929BcB89'
-    const vIDIA = await vIDIAFactory.deploy(
-      'vIDIA contract',
-      'VIDIA',
-      owner.address,
-      testTokenAddress
-    )
+      if (i !== 2) // fee setters should throw when setting >100%
+        await expect(fns[i].set(10001)).to.be.revertedWith('Fee must be less than 100%')
+    }
   })
 
-  it('sets penalty of a token', async function () {
-
-    const penalty = 10
-
-    await vIDIA.updateSkipUnstakeDelayFee(penalty)
-
-    const value = (await vIDIA.skipUnstakeDelayFee()).toNumber()
-    expect(value).to.eq(10)
-  })
-
-  it('cannot set penalty of a token', async function () {
-    const penalty = 10
-
-    await expect
-    (vIDIA.connect(vester).updateSkipUnstakeDelayFee(penalty)
-    ).to.be.revertedWith('Must have fee setter role')
-
-  })
-
-  it('sets delay of a token', async function () {
- 
-    const delay = 10
-
-    await vIDIA.updateUnvestingDelay(delay)
-    const value = (await vIDIA.unstakingDelay()).toNumber()
-    expect(value).to.eq(10)
-  })
-
-  it('deploys and cannot set delay of a token, thus still 0', async function () {
-
-    const delay = 10
-
-    await expect
-    (vIDIA.connect(vester).updateUnvestingDelay(delay)
-    ).to.be.revertedWith('Must have delay setter role')
-  })
-
-  it('deploys and stakes tokens', async function () {
+  it('test stake tokens', async function () {
     const transferAmt = 10000000
-    await VestToken.transfer(vester.address, transferAmt) 
-    await VestToken.connect(vester).approve(vIDIA.address, ethers.constants.MaxUint256)
-    const firstStakeAmt = 100
-    const secondStakeAmt = 250
-    await vIDIA.connect(vester).stake(firstStakeAmt)
-    let totalStaked = (await vIDIA.totalStakedAmount()).toNumber()
-    expect(totalStaked).to.eq(firstStakeAmt)
+    await underlying.transfer(vester.address, transferAmt) 
+    await underlying.connect(vester).approve(vIDIA.address, ethers.constants.MaxUint256)
+    const stakeAmt = [100, 250]
 
-    await vIDIA.connect(vester).stake(secondStakeAmt)
-    totalStaked = (await vIDIA.totalStakedAmount()).toNumber()
-    expect(totalStaked).to.eq(firstStakeAmt + secondStakeAmt)
+    for (let i = 0; i < stakeAmt.length; i++) {
+      await vIDIA.connect(vester).stake(stakeAmt[i])
+      expect((await vIDIA.totalStakedAmount()).toNumber())
+        .to.eq(stakeAmt.reduce((prev, curr, idx) => idx <= i ? prev+curr : prev))
+    }
   })
 
-  it('stakes and unstakes tokens', async function () {
+  it('test stake/unstake', async function () {
     const transferAmt = 10000000
-    await VestToken.transfer(vester.address, transferAmt) 
-    await VestToken.connect(vester).approve(vIDIA.address, ethers.constants.MaxUint256)
+    await underlying.transfer(vester.address, transferAmt) 
+    await underlying.connect(vester).approve(vIDIA.address, ethers.constants.MaxUint256)
     const firstStakeAmt = 100
     const secondStakeAmt = 250
     await vIDIA.connect(vester).stake(firstStakeAmt)
@@ -136,10 +101,8 @@ export default describe('vIDIA', function () {
     expect(userData.unstakedAmount).to.eq(secondStakeAmt)
     const unstakeTime = (await getBlockTime()) + (await vIDIA.unstakingDelay()).toNumber()
     expect(userData.unstakeAt).to.eq(unstakeTime)
-    await expect
-    (vIDIA.connect(vester).unstake(firstStakeAmt)
-    ).to.be.revertedWith('User already has pending tokens unstaking')
-
+    await expect(vIDIA.connect(vester).unstake(firstStakeAmt))
+      .to.be.revertedWith('User already has pending tokens unstaking')
 
   })
 
@@ -151,39 +114,39 @@ export default describe('vIDIA', function () {
       MaxUint256
     )
     const vidiaFactory = await ethers.getContractFactory('vIDIA')
-    const vidia = await vidiaFactory.deploy(
+    const vIDIA = await vidiaFactory.deploy(
       'Vested IDIA',
-      'VIDIA',
+      'vIDIA',
       owner.address,
       underlying.address
     )
 
-    await underlying.approve(vidia.address, MaxUint256)
-    await vidia.stake(WeiPerEth)
-    await vidia.approve(vester.address, MaxUint256)
+    await underlying.approve(vIDIA.address, MaxUint256)
+    await vIDIA.stake(WeiPerEth)
+    await vIDIA.approve(vester.address, MaxUint256)
 
     const checkFailure = async () => {
-      await expect(vidia.transfer(vester.address, one)).to.be.revertedWith(
+      await expect(vIDIA.transfer(vester.address, _1)).to.be.revertedWith(
         'Origin and dest address not in whitelist'
       )
       await expect(
-        vidia.connect(vester).transferFrom(owner.address, vester.address, one)
+        vIDIA.connect(vester).transferFrom(owner.address, vester.address, _1)
       ).to.be.revertedWith('Origin and dest address not in whitelist')
     }
 
     const checkSuccess = async () => {
-      await expect(vidia.transfer(vester.address, one))
-        .to.emit(vidia, 'Transfer')
-        .withArgs(owner.address, vester.address, one)
+      await expect(vIDIA.transfer(vester.address, _1))
+        .to.emit(vIDIA, 'Transfer')
+        .withArgs(owner.address, vester.address, _1)
       await expect(
-        vidia.connect(vester).transferFrom(owner.address, vester.address, one)
+        vIDIA.connect(vester).transferFrom(owner.address, vester.address, _1)
       )
-        .to.emit(vidia, 'Transfer')
-        .withArgs(owner.address, vester.address, one)
+        .to.emit(vIDIA, 'Transfer')
+        .withArgs(owner.address, vester.address, _1)
     }
 
     const checkWhitelist = async (addrArr: string[]) => {
-      expect(JSON.stringify(await vidia.getAllWhitelistedAddrs())).to.eq(
+      expect(JSON.stringify(await vIDIA.getAllWhitelistedAddrs())).to.eq(
         JSON.stringify(addrArr)
       )
     }
@@ -193,76 +156,161 @@ export default describe('vIDIA', function () {
     await checkFailure()
 
     // case 2: source addr in whitelist, should not fail xfer
-    await vidia.addToWhitelist(owner.address)
+    await vIDIA.addToWhitelist(owner.address)
     await checkWhitelist([owner.address])
     await checkSuccess()
 
     // case 3: source addr and dest addr in whitelist, should not fail xfer
-    await vidia.addToWhitelist(vester.address)
+    await vIDIA.addToWhitelist(vester.address)
     await checkWhitelist([owner.address, vester.address])
     await checkSuccess()
 
     // case 4: dest addr in whitelist, should not fail xfer
-    await vidia.removeFromWhitelist(owner.address)
+    await vIDIA.removeFromWhitelist(owner.address)
     await checkWhitelist([vester.address])
     await checkSuccess()
 
     // case 5: remove all addr from whitelist, should fail xfer
-    await vidia.removeFromWhitelist(vester.address)
+    await vIDIA.removeFromWhitelist(vester.address)
     await checkWhitelist([])
     await checkFailure()
   })
 
   it('test claimstaked', async () => {
-    const TestTokenFactory = await ethers.getContractFactory('GenericToken')
-    const underlying = await TestTokenFactory.connect(owner).deploy(
-      'Test',
-      'TT',
-      convToBN(200)
-    )
-    const vidiaFactory = await ethers.getContractFactory('vIDIA')
-    const vidia = await vidiaFactory.deploy(
-      'Vested IDIA',
-      'VIDIA',
-      owner.address,
-      underlying.address
-    )
+    await underlying.approve(vIDIA.address, MaxUint256)
+    await vIDIA.stake(convToBN(200))
 
-    await underlying.approve(vidia.address, MaxUint256)
-    await vidia.stake(convToBN(200))
+    const withdrawAmt = [convToBN(1), convToBN(12), convToBN(0), convToBN(123)]
 
-    const testCases = [convToBN(1), convToBN(12), convToBN(0), convToBN(123)]
+    let userVidiaBalance = await vIDIA.balanceOf(owner.address)
+    let userUnderlying = await underlying.balanceOf(owner.address)
+    let contractUnderlying = await underlying.balanceOf(vIDIA.address)
+    let sumFees = await vIDIA.accumulatedFee()
 
-    let userPrevVidiaBalance = await vidia.balanceOf(owner.address)
-    let userPrevUnderlying = await underlying.balanceOf(owner.address)
-    let contractPrevUnderlying = await underlying.balanceOf(vidia.address)
-    let prevFee = await vidia.accumulatedFee()
+    const feePercentBasisPts = await vIDIA.skipDelayFee()
 
-
-    const feePercentBasisPts = await vidia.skipUnstakeDelayFee()
-
-    for (let i = 0; i < testCases.length; i++) {
+    for (let i = 0; i < withdrawAmt.length; i++) {
       
-      const fee = feePercentBasisPts.mul(testCases[i]).div(ethers.BigNumber.from('10000')) // 10000 basis pts = 100%
-      const receiveAmt = testCases[i].sub(fee)
+      const fee = feePercentBasisPts.mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
+      const receiveAmt = withdrawAmt[i].sub(fee)
 
-      const reward = await vidia.calculateUserReward()
+      const reward = await vIDIA.calculateUserReward()
 
-      expect(await vidia.claimStaked(testCases[i]))
-        .to.emit(vidia, 'ClaimStaked')
+      expect(await vIDIA.claimStaked(withdrawAmt[i]))
+        .to.emit(vIDIA, 'ClaimReward')
+        .withArgs(owner.address, reward)
+        .to.emit(underlying, 'Transfer')
+        .withArgs(vIDIA.address, owner.address, reward)
+        .to.emit(vIDIA, 'ClaimStaked')
         .withArgs(owner.address, fee, receiveAmt)
         .to.emit(underlying, 'Transfer')
-        .withArgs(vidia.address, owner.address, receiveAmt)
+        .withArgs(vIDIA.address, owner.address, receiveAmt)
 
-      expect(await vidia.balanceOf(owner.address)).to.equal(userPrevVidiaBalance.sub(testCases[i]))
-      expect(await underlying.balanceOf(owner.address)).to.equal(userPrevUnderlying.add(receiveAmt).add(reward))
-      expect(await vidia.accumulatedFee()).to.equal(prevFee.add(fee))
-      expect(await underlying.balanceOf(vidia.address)).to.equal(contractPrevUnderlying.sub(receiveAmt).sub(reward))
+      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance.sub(withdrawAmt[i]))
+      expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(receiveAmt).add(reward))
+      expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
+      expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying.sub(receiveAmt).sub(reward))
 
-      userPrevVidiaBalance = userPrevVidiaBalance.sub(testCases[i])
-      userPrevUnderlying = userPrevUnderlying.add(receiveAmt).add(reward)
-      contractPrevUnderlying = contractPrevUnderlying.sub(receiveAmt).sub(reward)
-      prevFee = prevFee.add(fee)
+      userVidiaBalance = userVidiaBalance.sub(withdrawAmt[i])
+      userUnderlying = userUnderlying.add(receiveAmt).add(reward)
+      contractUnderlying = contractUnderlying.sub(receiveAmt).sub(reward)
+      sumFees = sumFees.add(fee)
     }
+  })
+
+  it('test claimpendingunstake with pending unstake', async () => {
+    await underlying.approve(vIDIA.address, MaxUint256)
+    const stakeAmt = 200
+    await vIDIA.stake(convToBN(stakeAmt))
+    await vIDIA.unstake(convToBN(stakeAmt))
+
+    const withdrawAmt = [convToBN(1), convToBN(8), convToBN(0), convToBN(102)]
+
+    let userVidiaBalance = await vIDIA.balanceOf(owner.address)
+    let userUnderlying = await underlying.balanceOf(owner.address)
+    let userUnstakingAmt = (await vIDIA.userInfo(owner.address)).unstakedAmount
+    let contractUnderlying = await underlying.balanceOf(vIDIA.address)
+    let sumFees = await vIDIA.accumulatedFee()
+
+    const feePercentBasisPts = await vIDIA.skipDelayFee()
+
+    for (let i = 0; i < withdrawAmt.length; i++) {
+      const fee = feePercentBasisPts.mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
+      const receiveAmt = withdrawAmt[i].sub(fee)
+
+      expect(await vIDIA.claimPendingUnstake(withdrawAmt[i]))
+        .to.emit(vIDIA, 'ClaimPendingUnstake')
+        .withArgs(owner.address, fee, receiveAmt)
+        .to.emit(underlying, 'Transfer')
+        .withArgs(vIDIA.address, owner.address, receiveAmt)
+
+      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance.sub(withdrawAmt[i]))
+      expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(receiveAmt))
+      expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
+      expect((await vIDIA.userInfo(owner.address)).unstakedAmount).to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
+      expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying.sub(receiveAmt))
+
+      userVidiaBalance = userVidiaBalance.sub(withdrawAmt[i])
+      userUnderlying = userUnderlying.add(receiveAmt)
+      userUnstakingAmt = userUnstakingAmt.sub(withdrawAmt[i])
+      contractUnderlying = contractUnderlying.sub(receiveAmt)
+      sumFees = sumFees.add(fee)
+    }
+
+    // test failure mode
+    mineTimeDelta(TWO_WEEKS)
+    expect(await vIDIA.claimPendingUnstake(0))
+      .to.be.revertedWith('Can unstake without paying fee')
+  })
+
+  it('test cancelpendingunstake with pending unstake', async () => {
+    await underlying.approve(vIDIA.address, MaxUint256)
+    const stakeAmt = 200
+    await vIDIA.stake(convToBN(stakeAmt))
+    await vIDIA.unstake(convToBN(stakeAmt))
+
+    const withdrawAmt = [convToBN(1), convToBN(6), convToBN(0), convToBN(99)]
+
+    let userVidiaBalance = await vIDIA.balanceOf(owner.address)
+    let userUnderlying = await underlying.balanceOf(owner.address)
+    let userUnstakingAmt = (await vIDIA.userInfo(owner.address)).unstakedAmount
+    let userStakedAmt = (await vIDIA.userInfo(owner.address)).stakedAmount
+    let contractUnderlying = await underlying.balanceOf(vIDIA.address)
+    let sumFees = await vIDIA.accumulatedFee()
+
+    const feePercentBasisPts = await vIDIA.cancelUnstakeFee()
+
+    for (let i = 0; i < withdrawAmt.length; i++) {
+      const fee = feePercentBasisPts.mul(withdrawAmt[i]).div(_10000) // 10000 basis pts = 100%
+      const receiveAmt = withdrawAmt[i].sub(fee)
+
+      const reward = await vIDIA.calculateUserReward()
+
+      expect(await vIDIA.cancelPendingUnstake(withdrawAmt[i]))
+        .to.emit(vIDIA, 'ClaimReward')
+        .withArgs(owner.address, reward)
+        .to.emit(underlying, 'Transfer')
+        .withArgs(vIDIA.address, owner.address, reward)
+        .to.emit(vIDIA, 'CancelPendingUnstake')
+        .withArgs(owner.address, fee, receiveAmt)
+
+      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance) // no change
+      expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(reward)) // receive reward
+      expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
+      expect((await vIDIA.userInfo(owner.address)).unstakedAmount).to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
+      expect((await vIDIA.userInfo(owner.address)).stakedAmount).to.equal(userStakedAmt.add(receiveAmt))
+      expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying)
+  
+      userUnderlying = userUnderlying.add(reward)
+      userUnstakingAmt = userUnstakingAmt.sub(withdrawAmt[i])
+      contractUnderlying = contractUnderlying.sub(reward)
+      userStakedAmt = userStakedAmt.add(receiveAmt)
+      sumFees = sumFees.add(fee)
+    }
+
+    // test failure mode
+    mineTimeDelta(TWO_WEEKS)
+    expect(await vIDIA.claimPendingUnstake(0))
+      .to.be.revertedWith('Can unstake without paying fee')
   })
 })

--- a/test/test-vIDIA.ts
+++ b/test/test-vIDIA.ts
@@ -244,13 +244,12 @@ export default describe('vIDIA', function () {
         .to.emit(underlying, 'Transfer')
         .withArgs(vIDIA.address, owner.address, receiveAmt)
 
-      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance.sub(withdrawAmt[i]))
+      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance)
       expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(receiveAmt))
       expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
       expect((await vIDIA.userInfo(owner.address)).unstakedAmount).to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
       expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying.sub(receiveAmt))
 
-      userVidiaBalance = userVidiaBalance.sub(withdrawAmt[i])
       userUnderlying = userUnderlying.add(receiveAmt)
       userUnstakingAmt = userUnstakingAmt.sub(withdrawAmt[i])
       contractUnderlying = contractUnderlying.sub(receiveAmt)
@@ -258,8 +257,8 @@ export default describe('vIDIA', function () {
     }
 
     // test failure mode
-    mineTimeDelta(TWO_WEEKS)
-    expect(await vIDIA.claimPendingUnstake(0))
+    await mineTimeDelta(TWO_WEEKS)
+    await expect(vIDIA.claimPendingUnstake(0))
       .to.be.revertedWith('Can unstake without paying fee')
   })
 
@@ -294,13 +293,14 @@ export default describe('vIDIA', function () {
         .to.emit(vIDIA, 'CancelPendingUnstake')
         .withArgs(owner.address, fee, receiveAmt)
 
-      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance) // no change
+      expect(await vIDIA.balanceOf(owner.address)).to.equal(userVidiaBalance.add(receiveAmt))
       expect(await underlying.balanceOf(owner.address)).to.equal(userUnderlying.add(reward)) // receive reward
       expect(await vIDIA.accumulatedFee()).to.equal(sumFees.add(fee))
       expect((await vIDIA.userInfo(owner.address)).unstakedAmount).to.equal(userUnstakingAmt.sub(withdrawAmt[i]))
       expect((await vIDIA.userInfo(owner.address)).stakedAmount).to.equal(userStakedAmt.add(receiveAmt))
       expect(await underlying.balanceOf(vIDIA.address)).to.equal(contractUnderlying)
   
+      userVidiaBalance = userVidiaBalance.add(receiveAmt)
       userUnderlying = userUnderlying.add(reward)
       userUnstakingAmt = userUnstakingAmt.sub(withdrawAmt[i])
       contractUnderlying = contractUnderlying.sub(reward)
@@ -309,8 +309,8 @@ export default describe('vIDIA', function () {
     }
 
     // test failure mode
-    mineTimeDelta(TWO_WEEKS)
-    expect(await vIDIA.claimPendingUnstake(0))
+    await mineTimeDelta(TWO_WEEKS)
+    await expect(vIDIA.claimPendingUnstake(0))
       .to.be.revertedWith('Can unstake without paying fee')
   })
 })

--- a/test/test-vIDIA.ts
+++ b/test/test-vIDIA.ts
@@ -51,6 +51,10 @@ export default describe('vIDIA', function () {
     )
   })
 
+  it('test static funcs', async function () {
+    expect(await vIDIA.supportsInterface('0xb0202a11')).to.eq(true)
+  })
+
   it('test setters', async function () {
     const value = [0, 100, 200, 300]
     const fns = [
@@ -210,9 +214,10 @@ export default describe('vIDIA', function () {
     await underlying.approve(vIDIA.address, MaxUint256)
     const stakeAmt = 200
     await vIDIA.stake(convToBN(stakeAmt))
-    await vIDIA.unstake(convToBN(stakeAmt))
+    await vIDIA.unstake(convToBN(stakeAmt-1))
 
-    const withdrawAmt = [convToBN(1), convToBN(8), convToBN(0), convToBN(102)]
+    // sums up to stakeAmt-1 for LOC coverage
+    const withdrawAmt = [convToBN(1), convToBN(8), convToBN(0), convToBN(102), convToBN(88)]
 
     let userVidiaBalance = await vIDIA.balanceOf(owner.address)
     let userUnderlying = await underlying.balanceOf(owner.address)
@@ -254,9 +259,10 @@ export default describe('vIDIA', function () {
     await underlying.approve(vIDIA.address, MaxUint256)
     const stakeAmt = 200
     await vIDIA.stake(convToBN(stakeAmt))
-    await vIDIA.unstake(convToBN(stakeAmt))
-
-    const withdrawAmt = [convToBN(1), convToBN(6), convToBN(0), convToBN(99)]
+    await vIDIA.unstake(convToBN(stakeAmt-1))
+  
+    // sums up to stakeAmt-1 for LOC coverage
+    const withdrawAmt = [convToBN(1), convToBN(6), convToBN(0), convToBN(99), convToBN(93)] 
 
     let userVidiaBalance = await vIDIA.balanceOf(owner.address)
     let userUnderlying = await underlying.balanceOf(owner.address)
@@ -300,5 +306,9 @@ export default describe('vIDIA', function () {
     await mineTimeDelta(TWO_WEEKS)
     await expect(vIDIA.claimPendingUnstake(0))
       .to.be.revertedWith('Can unstake without paying fee')
+  })
+
+  it('test claimunstaked', async () => {
+    await vIDIA.claimUnstaked()
   })
 })

--- a/test/test-vIDIA.ts
+++ b/test/test-vIDIA.ts
@@ -28,7 +28,7 @@ export default describe('vIDIA', function () {
   beforeEach(async function () {
     // Get the ContractFactory and Signers here.
     // Token = await ethers.getContractFactory("Token");
-    ;[owner, vester] = await ethers.getSigners()
+    [owner, vester] = await ethers.getSigners()
 
     // To deploy our contract, we just have to call Token.deploy() and await
     // for it to be deployed(), which happens once its transaction has been
@@ -104,25 +104,11 @@ export default describe('vIDIA', function () {
       (await getBlockTime()) + (await vIDIA.unstakingDelay()).toNumber()
     expect(userData.unstakeAt).to.eq(unstakeTime)
     await expect(vIDIA.connect(vester).unstake(firstStakeAmt))
-      .to.be.revertedWith('User already has pending tokens unstaking')
+      .to.be.revertedWith('User has pending tokens unstaking')
 
   })
 
   it('test whitelist feature', async () => {
-    const TestTokenFactory = await ethers.getContractFactory('GenericToken')
-    const underlying = await TestTokenFactory.connect(owner).deploy(
-      'Test',
-      'TT',
-      MaxUint256
-    )
-    const vidiaFactory = await ethers.getContractFactory('vIDIA')
-    const vIDIA = await vidiaFactory.deploy(
-      'Vested IDIA',
-      'vIDIA',
-      owner.address,
-      underlying.address
-    )
-
     await underlying.approve(vIDIA.address, MaxUint256)
     await vIDIA.stake(WeiPerEth)
     await vIDIA.approve(vester.address, MaxUint256)


### PR DESCRIPTION
![Screen Shot 2022-03-22 at 5 47 05 PM](https://user-images.githubusercontent.com/86365704/159581732-7e0b8a2e-d892-4573-8d45-3166ca361f56.png)

add tests for cancel/claim pending unstaking tokens, improve test coverage, fix formatting
Note: coverage not 100% b/c of line 381 which requires usage of _msgData internally